### PR TITLE
refactor(header): update logo image prop structure to use asset object

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -17,8 +17,8 @@ export default async function Header() {
 			logo={{
 				name: logo?.name,
 				image: {
-					dark: logo?.image?.dark?.asset?.url,
-					default: logo?.image?.default?.asset?.url
+					dark: logo?.image?.dark?.asset,
+					default: logo?.image?.default?.asset
 				}
 			}}
 			title={title}


### PR DESCRIPTION
The change simplifies the logo image prop structure by directly using the asset object instead of accessing the url property. This makes the code more consistent with how assets are typically handled in the codebase.