### PR TITLE
refactor(ui): simplify Pretitle component props interface

### DIFF
--- a/src/ui/Pretitle.tsx
+++ b/src/ui/Pretitle.tsx
@@ -5,9 +5,10 @@ import { Button } from '@heroui/react'
 import { JSX } from 'react'
 
 export default function Pretitle({
-																	 className,
-																	 children,
-																 }: JSX.Element) {
+	children
+}: {
+	children?: React.ReactNode
+}) {
 	if (!children) return null
 
 	return (


### PR DESCRIPTION
Remove className prop and explicitly type children as React.ReactNode