### PR TITLE
Update import path for service page components

### DIFF
--- a/src/app/(frontend)/services/[slug]/page.tsx
+++ b/src/app/(frontend)/services/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { AboutSection, HeroSection } from '@/components/service/service-list-page'
+import { AboutSection, HeroSection } from '@/components/service/service-page'
 
 export default function ServicePage() {
 	return (


### PR DESCRIPTION
Changed the import path from 'service-list-page' to 'service-page' to correctly reference AboutSection and HeroSection components.