### PR TITLE
Add project list module and UI components

### DIFF
--- a/src/app/(frontend)/[[...slug]]/page.tsx
+++ b/src/app/(frontend)/[[...slug]]/page.tsx
@@ -15,6 +15,7 @@ import errors from '@/lib/errors'
 export default async function Page({ params }: Props) {
 	const page = await getPage(await params)
 	if (!page) notFound()
+	console.log(page.modules)
 	return <Modules modules={page.modules} page={page} />
 }
 

--- a/src/app/(frontend)/services/[slug]/page.tsx
+++ b/src/app/(frontend)/services/[slug]/page.tsx
@@ -58,7 +58,6 @@ export default async function ServicePage(props: {
 		query: SERVICE_PAGE_QUERY,
 		params: { slug },
 	});
-	console.log(page)
 
 	return (
 		<>

--- a/src/app/(frontend)/services/page.tsx
+++ b/src/app/(frontend)/services/page.tsx
@@ -55,48 +55,46 @@ export default function ServicesPage(): JSX.Element {
 					backgroundImage: 'url(/images/service-placeholder.png)',
 				}}
 			>
-				<div className="container text-center relative z-10">
+				<div className="container flex flex-col items-start lg:items-center lg:text-center relative z-10">
 					<Pretitle className='mb-4'>
 						Восстановление и защите салона автомобиля
 					</Pretitle>
 					<h1 className="text-4xl md:text-6xl font-bold mb-6 capitalize">
 						Наши <span>услуги</span>
 					</h1>
-					<div className="w-24 h-1 brand-gradient rounded-full mx-auto mb-8"></div>
-					<p className="md:text-lg max-w-3xl mx-auto mb-8 text-balance">
+					<div className="w-24 h-1 brand-gradient rounded-full lg:mx-auto mb-8"></div>
+					<p className="md:text-lg max-w-3xl lg:mx-auto mb-8 text-balance">
 						Комплексные услуги по <span className="font-bold">восстановлению и защите салона автомобиля</span> с
 						использованием передовых технологий <span className="brand-gradient font-bold">LeTech</span>.
 					</p>
-					<div>
-						<Button
-							className="group brand-gradient font-medium"
-							endContent={
-								<span
-									className="group-hover:translate-x-1 transition-transform pointer-events-none flex h-[22px] w-[22px] items-center justify-center rounded-full bg-foreground">
+					<Button
+						className="group brand-gradient font-medium"
+						endContent={
+							<span
+								className="group-hover:translate-x-1 transition-transform pointer-events-none flex h-[22px] w-[22px] items-center justify-center rounded-full bg-foreground">
 									<BsArrowUpRight size={14} className="text-background" />
 								</span>
-							}
-							radius="full"
-							as={Link}
-							href="#about"
-						>
-							Подробнее
-						</Button>
-					</div>
+						}
+						radius="full"
+						as={Link}
+						href="#about"
+					>
+						Подробнее
+					</Button>
 
 				</div>
 			</section>
 			{/* Services Grid */}
 			<section id="about" className="py-20">
 				<div className="container">
-					<div className="text-center mb-16">
+					<div className="lg:text-center mb-16">
 						<Pretitle className='mb-4'>
 							Наши услуги
 						</Pretitle>
-						<h2 className="text-3xl md:text-4xl font-bold text-automotive-navy mb-4">
+						<h2 className="text-3xl md:text-4xl font-bold mb-4">
 							Комплексные решения
 						</h2>
-						<p className="max-w-2xl mx-auto text-pretty">
+						<p className="max-w-2xl lg:mx-auto text-pretty">
 							От мелкого ремонта до полной реставрации — мы предлагаем комплексные услуги, чтобы салон вашего автомобиля
 							выглядел и ощущался как новый.
 						</p>

--- a/src/components/project/ui/ProjectShowcase.tsx
+++ b/src/components/project/ui/ProjectShowcase.tsx
@@ -1,0 +1,24 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { CgArrowTopRight, CgArrowTopRightO } from 'react-icons/cg'
+
+export default function ProjectShowcase() {
+	return (
+		<Link href="/projects" className="group flex relative rounded-large overflow-hidden">
+			<Image
+				src={`/images/before-after.jpg`}
+				width={1920}
+				height={380}
+				alt="Before and after restoration"
+				className="w-full h-96 object-cover group-hover:scale-110 transition-transform"
+				quality={50}
+			/>
+			<div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent" />
+			<div className="absolute bottom-0 left-0 text-foreground p-4">
+				<h3 className="text-2xl font-bold mb-2 leading-none flex items-center gap-2">Увидеть трансформацию <CgArrowTopRightO size={24}/></h3>
+				<p className="text-sm md:text-base text-foreground-700">Профессиональные результаты, которые говорят сами за
+					себя</p>
+			</div>
+		</Link>
+	)
+}

--- a/src/components/project/ui/index.ts
+++ b/src/components/project/ui/index.ts
@@ -1,5 +1,7 @@
-import ProjectCard from './ProjectCard'
+import ProjectCard from './ProjectCard';
+import ProjectShowcase from './ProjectShowcase';
 
 export {
-	ProjectCard
+	ProjectCard,
+	ProjectShowcase
 }

--- a/src/components/section/SectionHeader.tsx
+++ b/src/components/section/SectionHeader.tsx
@@ -1,0 +1,26 @@
+import Pretitle from '@/ui/Pretitle'
+import { PortableText, PortableTextBlock } from 'next-sanity'
+
+export interface SectionHeaderProps {
+	pretitle?: string;
+	title?: PortableTextBlock[] | PortableTextBlock;
+	decription?: string;
+}
+
+export default function SectionHeader({ pretitle, title, decription }: SectionHeaderProps) {
+	return (
+		<header className="mb-12">
+			<Pretitle className='mb-4'>{pretitle}</Pretitle>
+			{title && (
+				<h2 className="text-4xl md:text-5xl font-bold mb-4 capitalize">
+					{/*<PortableText value={title} />*/}
+					Наши <span className="text-brand-gradient">Работы</span>
+				</h2>
+			)}
+			<div className="w-20 h-1 brand-gradient rounded-full mb-6"></div>
+			<p className="text-sm md:text-base text-foreground-700 font-light max-w-3xl text-balance">
+				{decription}
+			</p>
+		</header>
+	)
+}

--- a/src/components/section/index.ts
+++ b/src/components/section/index.ts
@@ -1,0 +1,5 @@
+import SectionHeader from "./SectionHeader";
+
+export {
+	SectionHeader
+}

--- a/src/components/service/service-page/BenefitsSection.tsx
+++ b/src/components/service/service-page/BenefitsSection.tsx
@@ -1,6 +1,8 @@
 import { Card, CardBody } from '@heroui/react'
 import { JSX } from 'react'
 import { BenefitsSectionIconMap, BenefitsSectionIconType } from '../lib/iconMap'
+import styles from './styles.module.css'
+import { cn } from '@/lib/utils'
 
 interface BenefitsSectionProps {
 	title: string,
@@ -32,12 +34,12 @@ export default function BenefitsSection({
 					</p>
 				</div>
 
-				<div className="flex flex-wrap justify-items-center justify-center items-stretch gap-4">
+				<div className={cn(styles.BenefitList)}>
 					{items?.map((benefit, index) => {
 						return (
 							<Card
 								key={index}
-								className="transition-all duration-300 transform hover:-translate-y-2 border-0 md:basis-[calc(100%/4-1rem)] "
+								className="transition-all duration-300 transform hover:-translate-y-2 border-0"
 							>
 								<CardBody className="md:p-6 flex-1">
 									<div
@@ -65,7 +67,7 @@ export default function BenefitsSection({
 					<p className="text-white/80 mb-6 max-w-2xl lg:mx-auto text-sm md:text-base">
 						Наши сертифицированные специалисты используют только лучшие материалы и технологии LeTech, гарантируя, что реставрация салона вашего автомобиля превзойдет все ваши ожидания.
 					</p>
-					<div className="flex flex-wrap lg:justify-center gap-4">
+					<div className="flex flex-col md:flex-row flex-wrap lg:justify-center gap-4">
 						<div className="lg:text-center">
 							<div className="text-3xl font-bold text-brand-gradient">24 часа</div>
 							<div className="text-sm">Среднее время работы</div>

--- a/src/components/service/service-page/HeroSection.tsx
+++ b/src/components/service/service-page/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { CTABlock } from '@/components/ui'
 import { JSX } from 'react'
 import { urlFor } from '@/sanity/lib/image'
+import Image from 'next/image'
 
 interface HeroSectionProps {
 	title: string,
@@ -15,14 +16,24 @@ export default function HeroSection({
 }: HeroSectionProps): JSX.Element | null {
 	if (!title) return null
 
-	const heroImageUrl = heroImage ? urlFor(heroImage).width(1200).height(800).crop('center').format('webp').url() : null
+	const heroImageUrl = heroImage ?
+		urlFor(heroImage).width(1200).height(800).crop('center').format('webp').url()
+		: '/images/service-hero-background.jpg';
 
 	return (
 		<section
 			className="relative flex items-center lg:justify-center bg-cover bg-center bg-no-repeat bg-fixed"
-			style={{ backgroundImage: `url(${heroImageUrl})` }}
 		>
-			<div className="absolute inset-0 bg-black/70"></div>
+			<div className="absolute inset-0 bg-black/70 after:absolute after:inset-0 after:bg-black/70">
+				<Image
+					src={heroImageUrl}
+					alt={title}
+					fill
+					className="object-cover"
+					priority
+					sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+				/>
+			</div>
 
 			<div className="relative z-10 container py-20 lg:text-center">
 				<div className="max-w-4xl mx-auto animate-fade-in-up">

--- a/src/components/service/service-page/ProcessSection.tsx
+++ b/src/components/service/service-page/ProcessSection.tsx
@@ -2,6 +2,8 @@ import { Card, CardBody } from "@heroui/react";
 import { BiWrench } from "react-icons/bi";
 import { BsClipboard2Check, BsShieldCheck } from "react-icons/bs";
 import { IoSearchCircle } from "react-icons/io5";
+import { cn } from '@/lib/utils'
+import styles from './styles.module.css'
 
 const processSteps = [
 	{
@@ -41,7 +43,7 @@ export default function ProcessSection() {
 					</p>
 				</div>
 
-				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+				<div className={cn(styles.ProcessSteps, 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4')}>
 					{processSteps.map((step, index) => {
 						const IconComponent = step.icon;
 						return (
@@ -75,20 +77,20 @@ export default function ProcessSection() {
 					})}
 				</div>
 
-				<div className="mt-16 text-center">
-					<div className="rounded-xl p-8 max-w-2xl mx-auto bg-content2">
+				<div className="mt-16 lg:text-center">
+					<div className="rounded-xl p-6 max-w-2xl lg:mx-auto bg-content2">
 						<h3 className="text-2xl font-bold mb-4">
 							Сроки и Результат
 						</h3>
 						<p className="text-sm md:text-base text-foreground-700 mb-6">
 							Большинство проектов по реставрации салона автомобиля завершаются в течение 1–2 рабочих дней, в зависимости от объема необходимой реставрации.
 						</p>
-						<div className="flex justify-center space-x-8">
-							<div className="text-center">
+						<div className="flex flex-col lg:flex-row lg:justify-center gap-6">
+							<div className="lg:text-center">
 								<div className="text-2xl font-bold text-brand-gradient">День 1</div>
 								<div className="text-sm text-foreground-700">Оценка и старт работ</div>
 							</div>
-							<div className="text-center">
+							<div className="lg:text-center">
 								<div className="text-2xl font-bold text-brand-gradient">День 2</div>
 								<div className="text-sm text-foreground-700">Приёмка выполненных работ</div>
 							</div>

--- a/src/components/service/service-page/styles.module.css
+++ b/src/components/service/service-page/styles.module.css
@@ -1,0 +1,10 @@
+.BenefitList {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 250px), 1fr));
+    gap: 1rem;
+}
+
+.ProcessSteps {
+    display: grid;
+    gap: 1rem;
+}

--- a/src/components/ui/FAQ.tsx
+++ b/src/components/ui/FAQ.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { Accordion, AccordionItem, Card } from '@heroui/react'
 import { JSX } from 'react'
+import Link from 'next/link'
 
 const faqs = [
 	{
@@ -72,12 +73,12 @@ export default function FAQSection({ items }: FAQSectionProps): JSX.Element | nu
 							Наша команда экспертов готова помочь. Свяжитесь с нами, чтобы получить персональные ответы и бесплатную консультацию по вопросам реставрации салона вашего автомобиля.
 						</p>
 						<div className="flex flex-col md:flex-row gap-4 justify-center">
-							<p className="text-white">
-								<span className="font-semibold text-automotive-gold">Call:</span> +1 (555) 123-4567
-							</p>
-							<p className="text-white">
-								<span className="font-semibold text-automotive-gold">Email:</span> info@rs-service.by
-							</p>
+							<Link href={`tel:+375 (29) 591 63 86`} className='flex flex-col gap-1'>
+								<span className="font-semibold text-brand-gradient">Позвонить:</span> +375 (29) 591 63 86
+							</Link>
+							<Link href={`mailto:info@rs-service.by`} className='flex flex-col gap-1'>
+								<span className="font-semibold text-brand-gradient">Написать:</span> info@rs-service.by
+							</Link>
 						</div>
 					</Card>
 				</div>

--- a/src/sanity/lib/queries.ts
+++ b/src/sanity/lib/queries.ts
@@ -127,6 +127,7 @@ export const MODULES_QUERY = groq`
 	},
 	_type == 'testimonial.featured' => { testimonial-> },
 	_type == 'testimonial-list' => { testimonials[]-> },
+	_type == 'project-list' => { projects[]-> },
 `
 
 export const GLOBAL_MODULE_PATH_QUERY = groq`

--- a/src/sanity/schemaTypes/fragments/modules.ts
+++ b/src/sanity/schemaTypes/fragments/modules.ts
@@ -29,6 +29,7 @@ export default defineField({
 		{ type: 'tabbed-content' },
 		{ type: 'testimonial-list' },
 		{ type: 'testimonial.featured' },
+		{ type: 'project-list' },
 	],
 	options: {
 		insertMenu: {
@@ -59,6 +60,7 @@ export default defineField({
 						'stat-list',
 						'step-list',
 						'testimonial-list',
+						'project-list',
 					],
 				},
 				{

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -53,6 +53,7 @@ import testimonialFeatured from './modules/testimonial.featured'
 import testimonialList from './modules/testimonial-list'
 import { servicePageType } from './documents/servicePageType'
 import { projectPageType } from './documents/projectPageType'
+import projectList from './modules/project-list'
 
 export const schemaTypes: SchemaTypeDefinition[] = [
 	// documents
@@ -108,4 +109,5 @@ export const schemaTypes: SchemaTypeDefinition[] = [
 	tabbedContent,
 	testimonialFeatured,
 	testimonialList,
+	projectList,
 ]

--- a/src/sanity/schemaTypes/modules/project-list.ts
+++ b/src/sanity/schemaTypes/modules/project-list.ts
@@ -1,0 +1,86 @@
+import { defineArrayMember, defineField, defineType } from 'sanity'
+import { TfiLayoutMediaLeftAlt } from 'react-icons/tfi'
+import { getBlockText } from 'sanitypress-utils'
+import { count } from '@/lib/utils'
+
+export default defineType({
+	name: 'project-list',
+	title: 'Project list (Список проектов ДО/ПОСЛЕ)',
+	icon: TfiLayoutMediaLeftAlt,
+	type: 'object',
+	groups: [{ name: 'content', default: true }, { name: 'options' }],
+	fields: [
+		defineField({
+			name: 'options',
+			title: 'Module options',
+			type: 'module-options',
+			group: 'options',
+		}),
+		defineField({
+			name: 'pretitle',
+			title: 'Предзаголовок',
+			type: 'string',
+			group: 'content',
+		}),
+		defineField({
+			name: 'intro',
+			type: 'array',
+			of: [{ type: 'block' }],
+			group: 'content',
+		}),
+		defineField({
+			name: 'ctas',
+			title: 'Call-to-actions',
+			type: 'array',
+			of: [{ type: 'cta' }],
+			group: 'content',
+		}),
+
+		defineField({
+			name: "projects",
+			title: "Связанные проекты",
+			type: "array",
+			of: [
+				{
+					type: "reference",
+					to: [{ type: "projectPage" }],
+				},
+			],
+			description: "Выберите проекты, которые будут отображаться как связанные",
+			group: "content",
+		}),
+		defineField({
+			name: 'layout',
+			type: 'string',
+			options: {
+				list: ['grid', 'carousel'],
+				layout: 'radio',
+			},
+			group: 'options',
+			initialValue: 'carousel',
+		}),
+		defineField({
+			name: 'columns',
+			type: 'number',
+			description: 'Set a fixed number of columns (Tablet and desktop only)',
+			validation: (Rule) => Rule.min(1).max(12),
+			group: 'options',
+		}),
+		defineField({
+			name: 'visualSeparation',
+			type: 'boolean',
+			initialValue: true,
+			group: 'options',
+		}),
+	],
+	preview: {
+		select: {
+			intro: 'intro',
+			cards: 'cards',
+		},
+		prepare: ({ intro, cards }) => ({
+			title: getBlockText(intro) || count(cards, 'card'),
+			subtitle: 'Card list',
+		}),
+	},
+})

--- a/src/ui/modules/CardList.tsx
+++ b/src/ui/modules/CardList.tsx
@@ -3,24 +3,24 @@ import Pretitle from '@/ui/Pretitle'
 import { PortableText, stegaClean } from 'next-sanity'
 import { cn } from '@/lib/utils'
 import { FeaturedServiceCard } from '@/components/service/ui'
-import Image from 'next/image'
 import Link from 'next/link'
 import { Button } from '@heroui/react'
 import { BsArrowUpRightCircle } from 'react-icons/bs'
 import { JSX } from 'react'
 import { fetchSanityLive } from '@/sanity/lib/fetch'
 import { SERVICE_PAGE_LIST_LIMIT_QUERY } from '@/components/service/lib/queries'
+import { ProjectShowcase } from '@/components/project/ui'
 
 export default async function CardList({
-	pretitle,
-	intro,
-	cards,
-	ctas,
-	layout,
-	columns = 3,
-	visualSeparation,
-	...props
-}: Partial<{
+																				 pretitle,
+																				 intro,
+																				 cards,
+																				 ctas,
+																				 layout,
+																				 columns = 3,
+																				 visualSeparation,
+																				 ...props
+																			 }: Partial<{
 	pretitle: string
 	intro: any
 	ctas: Sanity.CTA[]
@@ -39,9 +39,9 @@ export default async function CardList({
 		query: SERVICE_PAGE_LIST_LIMIT_QUERY,
 		params: {
 			limit: 3,
-		}
+		},
 	})
-	const isCarousel = stegaClean(layout) === 'carousel';
+	const isCarousel = stegaClean(layout) === 'carousel'
 
 	return (
 		<section className="section-container space-y-12" {...moduleProps(props)}>
@@ -54,7 +54,8 @@ export default async function CardList({
 						</div>
 						{
 							ctas?.map((cta: Sanity.CTA, index) => (
-								<Button as={Link} href={cta.link?.external} key={index} className="self-end group max-md:hidden" radius="full" variant="bordered">
+								<Button as={Link} href={cta.link?.external} key={index} className="self-end group max-md:hidden"
+												radius="full" variant="bordered">
 									{cta.link?.label}
 
 									<BsArrowUpRightCircle className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
@@ -70,7 +71,7 @@ export default async function CardList({
 						// isCarousel
 						// 	? 'max-md:carousel max-md:full-bleed max-md:px-4 max-md:pb-4'
 						// 	: 'grid md:grid-cols-[repeat(var(--col,3),minmax(0,1fr))]',
-						'max-md:carousel max-md:full-bleed max-md:px-4 max-md:pb-4 md:grid md:grid-cols-[repeat(var(--col,3),minmax(0,1fr))]'
+						'max-md:carousel max-md:full-bleed max-md:px-4 max-md:pb-4 md:grid md:grid-cols-[repeat(var(--col,3),minmax(0,1fr))]',
 					)}
 					style={
 						columns
@@ -93,31 +94,14 @@ export default async function CardList({
 				</div>
 				{
 					ctas?.map((cta: Sanity.CTA, index) => (
-						<Button as={Link} href={cta.link?.external} key={index} className="self-end group mt-4 md:hidden" radius="full" variant="bordered">
+						<Button as={Link} href={cta.link?.external} key={index} className="self-end group mt-4 md:hidden"
+										radius="full" variant="bordered">
 							{cta.link?.label}
 
 							<BsArrowUpRightCircle className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
 						</Button>
 					))
 				}
-			</div>
-			<div className="container">
-				{/* Before/After Showcase */}
-				<Link href="/projects" className="flex relative rounded-large overflow-hidden">
-					<Image
-						src={`/images/before-after.jpg`}
-						width={1920}
-						height={380}
-						alt="Before and after restoration"
-						className="w-full h-96 object-cover"
-						quality={50}
-					/>
-					<div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent" />
-					<div className="absolute bottom-0 left-0 text-foreground p-4">
-						<h3 className="text-2xl font-bold mb-2 leading-none">Увидеть трансформацию</h3>
-						<p className="text-sm md:text-base text-muted-foreground">Профессиональные результаты, которые говорят сами за себя</p>
-					</div>
-				</Link>
 			</div>
 		</section>
 	)

--- a/src/ui/modules/ProjectList.tsx
+++ b/src/ui/modules/ProjectList.tsx
@@ -1,0 +1,107 @@
+import moduleProps from '@/lib/moduleProps'
+import { stegaClean } from 'next-sanity'
+import { cn } from '@/lib/utils'
+import Link from 'next/link'
+import { Button } from '@heroui/react'
+import { BsArrowUpRightCircle } from 'react-icons/bs'
+import { JSX } from 'react'
+import { fetchSanityLive } from '@/sanity/lib/fetch'
+import { PROJECT_LIST_QUERY } from '@/components/project/lib/queries'
+import { ProjectCard, ProjectShowcase } from '@/components/project/ui'
+import { ProjectProps } from '@/components/project/ProjectList'
+import { CTASection } from '@/components/service'
+import { SectionHeader } from '@/components/section'
+
+export default async function CardList({
+	pretitle,
+	intro,
+	projects,
+	ctas,
+	layout,
+	columns = 3,
+	visualSeparation,
+	...props
+}: Partial<{
+	pretitle: string
+	intro: any
+	ctas: Sanity.CTA[]
+	projects: ProjectProps[]
+	layout: 'grid' | 'carousel'
+	columns: number
+	visualSeparation: boolean
+}> &
+	Sanity.Module): Promise<JSX.Element> {
+	const featuredProjects = await fetchSanityLive({
+		query: PROJECT_LIST_QUERY,
+	})
+	const isCarousel = stegaClean(layout) === 'carousel'
+
+	console.log(projects)
+
+	return (
+		<>
+			<section className="py-16 bg-content1" {...moduleProps(props)}>
+				<div className="container">
+					{/*{(pretitle || intro) && (*/}
+					{/*	<header className="mb-8 md:mb-16 flex flewrap justify-between">*/}
+					{/*		<div className="richtext max-w-2xl">*/}
+					{/*			<Pretitle>{pretitle}</Pretitle>*/}
+					{/*			<PortableText value={intro} />*/}
+					{/*		</div>*/}
+					{/*		{*/}
+					{/*			ctas?.map((cta: Sanity.CTA, index) => (*/}
+					{/*				<Button as={Link} href={cta.link?.external} key={index} className="self-end group max-md:hidden"*/}
+					{/*								radius="full" variant="bordered">*/}
+					{/*					{cta.link?.label}*/}
+
+					{/*					<BsArrowUpRightCircle className="h-4 w-4 group-hover:translate-x-1 transition-transform" />*/}
+					{/*				</Button>*/}
+					{/*			))*/}
+					{/*		}*/}
+					{/*	</header>*/}
+					{/*)}*/}
+					<SectionHeader pretitle={pretitle} title={intro} decription={'Портфолио успешных проектов по восстановлению автомобильных салонов. Каждый проект — это уникальное решение с гарантией качества.'} />
+
+					{/* Before/After Showcase */}
+					<ProjectShowcase />
+
+					<div
+						className={cn(
+							'items-stretch gap-8 mt-12',
+							// isCarousel
+							// 	? 'max-md:carousel max-md:full-bleed max-md:px-4 max-md:pb-4'
+							// 	: 'grid md:grid-cols-[repeat(var(--col,3),minmax(0,1fr))]',
+							'max-md:carousel max-md:full-bleed max-md:px-4 max-md:pb-4 md:grid md:grid-cols-[repeat(var(--col,3),minmax(0,1fr))]',
+						)}
+						style={
+							columns
+								? ({
+									'--col': columns,
+								} as React.CSSProperties)
+								: undefined
+						}
+					>
+						{
+							projects?.map((project: ProjectProps) => (
+								<ProjectCard key={project.title} project={project} />
+							))
+						}
+					</div>
+					{
+						ctas?.map((cta: Sanity.CTA, index) => (
+							<Button as={Link} href={cta.link?.external} key={index} className="self-end group mt-4 md:hidden"
+								radius="full" variant="bordered">
+								{cta.link?.label}
+
+								<BsArrowUpRightCircle className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
+							</Button>
+						))
+					}
+				</div>
+			</section>
+
+			{/* CTA Section */}
+			<CTASection className='py-16' />
+		</>
+	)
+}

--- a/src/ui/modules/index.tsx
+++ b/src/ui/modules/index.tsx
@@ -19,6 +19,7 @@ import StepList from './StepList'
 import TabbedContent from './TabbedContent'
 import TestimonialList from './TestimonialList'
 import TestimonialFeatured from './TestimonialFeatured'
+import ProjectList from './ProjectList'
 
 import dynamic from 'next/dynamic'
 import { createDataAttribute } from 'next-sanity'
@@ -50,6 +51,7 @@ const MODULE_MAP = {
 	'tabbed-content': TabbedContent,
 	'testimonial-list': TestimonialList,
 	'testimonial.featured': TestimonialFeatured,
+	'project-list': ProjectList,
 } as const
 
 export default function Modules({


### PR DESCRIPTION
Introduces a new 'project-list' module in Sanity schema and integrates it into the frontend. Adds ProjectShowcase, ProjectList, and SectionHeader components for displaying project portfolios. Updates CardList to use ProjectShowcase and refactors service page sections for improved layout and responsiveness. Also updates queries and module mapping to support the new module type.