### PR TITLE
Refactor breadcrumbs logic and enhance hero sections

### DIFF
--- a/src/app/(frontend)/projects/[slug]/page.tsx
+++ b/src/app/(frontend)/projects/[slug]/page.tsx
@@ -14,6 +14,7 @@ import { FaServicestack } from 'react-icons/fa'
 import { PiSteeringWheel } from 'react-icons/pi'
 import { JSX } from 'react'
 import Breadcrumbs from '@/ui/modules/Breadcrumbs'
+import { getBreadcrumbs } from '@/lib/crumbs'
 
 // Example mock data (replace with Sanity later)
 const stats: Stat[] = [
@@ -134,33 +135,7 @@ export default async function ProjectPage(props: {
 	const project = await fetchSanityLive({ query: PROJECT_QUERY, params: { slug } })
 	const heroImage = urlFor(project?.image).width(1200).height(630).format('webp').url()
 	const description = project?.description
-	const crumbs = [
-		{
-			internal: {
-				slug: {
-					current: 'index',
-					_type: 'slug',
-				},
-			},
-			label: 'Главная',
-			type:
-				'internal',
-			_key:
-				'692634eb5e13',
-			_type:
-				'link',
-		},
-		{
-			external: '/projects',
-			label: 'Наши Работы',
-			type:
-				'external',
-			_key:
-				'234234',
-			_type:
-				'link',
-		},
-	]
+	const { crumbs, currentPage } = getBreadcrumbs(project.title, [{label: 'Наши Работы', url: '/projects'}]);
 
 	if (!project) return <NotFound />
 
@@ -168,7 +143,7 @@ export default async function ProjectPage(props: {
 		<>
 			<HeroSection title="Ремонт и восстановление" subtitleHighlight="кожаного салона" stats={stats}
 									 heroImage={heroImage} />
-			<Breadcrumbs crumbs={crumbs as any} currentPage={project} />
+			<Breadcrumbs crumbs={crumbs as any} currentPage={currentPage} />
 			<DescriptionSection description={description} />
 			<StepsSection steps={steps} />
 			<ResultsSection beforeImages={beforeImages} afterImages={afterImages} />

--- a/src/app/(frontend)/projects/page.tsx
+++ b/src/app/(frontend)/projects/page.tsx
@@ -7,6 +7,7 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { BsArrowLeft } from "react-icons/bs";
 import Breadcrumbs from '@/ui/modules/Breadcrumbs'
+import { getBreadcrumbs } from '@/lib/crumbs'
 
 export const metadata: Metadata = {
 	title: "Проекты | RS Service",
@@ -39,26 +40,7 @@ export const metadata: Metadata = {
 
 export default async function ProjectsPage() {
 	const projects = await fetchSanityLive({ query: PROJECT_LIST_QUERY });
-	const crumbs = [
-		{
-			internal: {
-				slug: {
-					current: 'index',
-					_type: 'slug',
-				},
-			},
-			label: 'Главная',
-			type:
-				'internal',
-			_key:
-				'692634eb5e13',
-			_type:
-				'link',
-		},
-	];
-	const currentPage: any = {
-		title: 'Наши проекты'
-	}
+	const {crumbs, currentPage} = getBreadcrumbs('Наши проекты', []);
 
 	if (!projects) {
 		return (
@@ -79,9 +61,12 @@ export default async function ProjectsPage() {
 	return (
 		<>
 			{/* Header */}
-			<section className="bg-ink py-12">
+			<section className="relative py-12 after:bg-content1 after:absolute after:inset-0 after:opacity-70 bg-cover bg-center bg-no-repeat"
+							 style={{
+								 backgroundImage: 'url(/images/service-placeholder.png)',
+							 }}>
 				<div className="container">
-					<div className="md:text-center flex flex-col items-start md:items-center">
+					<div className="md:text-center flex flex-col items-start md:items-center relative z-10">
 						<Button
 							size="sm"
 							variant="ghost"

--- a/src/app/(frontend)/services/[slug]/page.tsx
+++ b/src/app/(frontend)/services/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { ContactUs } from '@/components/contact-us'
 import ProjectsSection from '@/components/service/service-page/ProjectsSection'
 import Breadcrumbs from '@/ui/modules/Breadcrumbs'
 import NotFound from '@/app/(frontend)/not-found'
+import { getBreadcrumbs } from '@/lib/crumbs'
 
 export async function generateMetadata(props: {
 	params: Promise<{ slug: string }>;
@@ -60,40 +61,14 @@ export default async function ServicePage(props: {
 		query: SERVICE_PAGE_QUERY,
 		params: { slug },
 	});
-	const crumbs = [
-		{
-			internal: {
-				slug: {
-					current: 'index',
-					_type: 'slug',
-				},
-			},
-			label: 'Главная',
-			type:
-				'internal',
-			_key:
-				'692634eb5e13',
-			_type:
-				'link',
-		},
-		{
-			external: '/services',
-			label: 'Наши Услуги',
-			type:
-				'external',
-			_key:
-				'234234',
-			_type:
-				'link',
-		},
-	];
+	const { crumbs, currentPage } = getBreadcrumbs(page?.title, [{label: 'Наши Услуги', url: '/services'}]);
 
 	if (!page) return <NotFound />
 
 	return (
 		<>
 			<HeroSection title={page?.title} description={page?.description} heroImage={page?.heroImage} />
-			<Breadcrumbs crumbs={crumbs as any} currentPage={page} />
+			<Breadcrumbs crumbs={crumbs as any} currentPage={currentPage} />
 			<AboutSection title={page?.title} description={page?.about} />
 			<BenefitsSection title={''} description={''} items={page?.benefits} />
 			<ProcessSection />

--- a/src/app/(frontend)/services/page.tsx
+++ b/src/app/(frontend)/services/page.tsx
@@ -5,6 +5,7 @@ import { BsArrowUpRight } from 'react-icons/bs'
 import Link from 'next/link'
 import Pretitle from '@/ui/Pretitle'
 import Breadcrumbs from '@/ui/modules/Breadcrumbs'
+import { getBreadcrumbs } from '@/lib/crumbs'
 
 export const generateMetadata = () => {
 	const url = `https://rs-service.by/services`;
@@ -48,31 +49,12 @@ export const generateMetadata = () => {
 };
 
 export default function ServicesPage(): JSX.Element {
-	const crumbs = [
-		{
-			internal: {
-				slug: {
-					current: 'index',
-					_type: 'slug',
-				},
-			},
-			label: 'Главная',
-			type:
-				'internal',
-			_key:
-				'692634eb5e13',
-			_type:
-				'link',
-		},
-	];
-	const currentPage: any = {
-		title: 'Наши услуги'
-	}
+	const {crumbs, currentPage} = getBreadcrumbs('Наши услуги', []);
 
 	return (
 		<>
 			{/* Hero Section */}
-			<section className="relative py-20 after:bg-content1 after:absolute after:inset-0 after:opacity-50 bg-cover bg-center bg-no-repeat"
+			<section className="relative py-20 after:bg-content1 after:absolute after:inset-0 after:opacity-70 bg-cover bg-center bg-no-repeat"
 				style={{
 					backgroundImage: 'url(/images/service-placeholder.png)',
 				}}

--- a/src/components/project/project-page/HeroSection.tsx
+++ b/src/components/project/project-page/HeroSection.tsx
@@ -1,5 +1,6 @@
 import { Card, CardBody } from '@heroui/react'
 import Pretitle from '@/ui/Pretitle'
+import { AiFillProject } from 'react-icons/ai'
 
 export interface HeroStatProps {
 	label: string;
@@ -25,6 +26,7 @@ export const HeroSection: React.FC<HeroSectionProps> = ({ title, subtitleHighlig
 			<div className="container relative z-10">
 				<div className="max-w-4xl">
 					<Pretitle className='mb-3'>
+						<AiFillProject className='text-secondary' size={16} />
 						Проект
 					</Pretitle>
 					<h1 className="text-4xl md:text-6xl mb-8 leading-none">

--- a/src/components/service/service-page/HeroSection.tsx
+++ b/src/components/service/service-page/HeroSection.tsx
@@ -2,6 +2,8 @@ import { CTABlock } from '@/components/ui'
 import { JSX } from 'react'
 import { urlFor } from '@/sanity/lib/image'
 import Image from 'next/image'
+import Pretitle from '@/ui/Pretitle'
+import { GrBusinessService } from 'react-icons/gr'
 
 interface HeroSectionProps {
 	title: string,
@@ -37,6 +39,10 @@ export default function HeroSection({
 
 			<div className="relative z-10 container py-20 lg:text-center">
 				<div className="max-w-4xl mx-auto animate-fade-in-up">
+					<Pretitle className='mb-3'>
+						<GrBusinessService className='text-secondary' size={16}/>
+						Услуга
+					</Pretitle>
 					<h1 className="text-5xl md:text-7xl font-bold text-white mb-6 text-balance break-words">
 						{title}{' '}
 						<span className="text-brand-gradient">LeTech Технологии</span>
@@ -61,7 +67,7 @@ export default function HeroSection({
 						</div>
 						<div className="bg-white/10 backdrop-blur-sm rounded-lg py-6 px-3 border border-white/20">
 							<div className="text-3xl font-bold text-automotive-gold mb-2">100%</div>
-							<div className="text-sm">удовлетворенность результатом</div>
+							<div className="text-sm">Удовлетворенность результатом</div>
 						</div>
 					</div>
 				</div>

--- a/src/lib/crumbs.ts
+++ b/src/lib/crumbs.ts
@@ -1,0 +1,37 @@
+export const getBreadcrumbs = (currentPageTitle: string, externalLink: { label: string, url: string }[] = []) => {
+	const BASE_CRUMBS = [
+		{
+			internal: {
+				slug: {
+					current: 'index',
+					_type: 'slug',
+				},
+			},
+			label: 'Главная',
+			type:
+				'internal',
+			_key:
+				'692634eb5e13',
+			_type:
+				'link',
+		},
+	];
+	const externalLinkCrumb = externalLink.map((link) => {
+		return {
+			external: link.url,
+			label: link.label,
+			type: 'external',
+			_key: '234234',
+			_type: 'link',
+		}
+	});
+	const crumbs = [...BASE_CRUMBS, ...externalLinkCrumb];
+	const currentPage: any = {
+		title: currentPageTitle,
+	}
+
+	return {
+		crumbs,
+		currentPage,
+	}
+}

--- a/src/ui/Pretitle.tsx
+++ b/src/ui/Pretitle.tsx
@@ -18,7 +18,7 @@ export default function Pretitle({
 			variant="bordered"
 			size='sm'
 		>
-			{stegaClean(children)}
+			{children}
 		</Button>
 	)
 }

--- a/src/ui/modules/Breadcrumbs.tsx
+++ b/src/ui/modules/Breadcrumbs.tsx
@@ -11,7 +11,6 @@ export default async function Breadcrumbs({
 	hideCurrent?: boolean
 	currentPage: Sanity.Page | Sanity.BlogPost
 }>): Promise<JSX.Element> {
-	console.log(currentPage)
 	return (
 		<nav className="section py-4 text-sm">
 			<ol


### PR DESCRIPTION
Moved breadcrumbs generation to a shared utility in src/lib/crumbs.ts and updated all relevant pages to use it, reducing duplication. Improved hero sections for project and service pages by adding icons and pretitle components. Minor UI adjustments and cleanup in Pretitle and Breadcrumbs components.